### PR TITLE
Updated addon to work with 2022.1. Bump version to 0.3.

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -20,7 +20,7 @@ addon_info = {
 	"addon_description" : _("""Kills NVDA.
 """),
 	# version
-	"addon_version" : "0.2",
+	"addon_version" : "0.3",
 	# Author(s)
 	"addon_author" : u"Tyler Spivey <tspivey@pcdesk.net>",
 	# URL for the add-on documentation support
@@ -30,7 +30,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
 	"addon_minimumNVDAVersion" : "2019.2.0",
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion" : "2021.1.0",
+	"addon_lastTestedNVDAVersion" : "2022.1.0",
 	# Add-on update channel (default is None, denoting stable releases, and for development releases, use "dev"; do not change unless you know what you are doing)
 	"addon_updateChannel" : None,
 }


### PR DESCRIPTION
NVDA 2022.1 broke manifests once again. Luckily, KillNVDA didn't break, all that needed to be done was a lastTestedNVDAVersion bump.
