### PR TITLE
Terminate source copies, not just NVDA.exe

### DIFF
--- a/addon/globalPlugins/killNVDA.py
+++ b/addon/globalPlugins/killNVDA.py
@@ -3,12 +3,11 @@
 import os
 from ctypes import *
 from ctypes.wintypes import *
-import subprocess
 import wx
 import gui
 import globalPluginHandler
+import comtypes.client
 
-PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
 PROCESS_TERMINATE = 0x0001
 
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):
@@ -24,41 +23,43 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		self.kill_item = None
 
 	def do_kill(self, evt):
-		dll = windll.psapi
-		kernel32 = windll.kernel32
-		dll.EnumProcesses.argtypes = (POINTER(DWORD), DWORD, POINTER(DWORD))
-		nprocs = 512
-		cbNeeded = DWORD()
-		while True:
-			procs = (DWORD * nprocs)()
-			res = dll.EnumProcesses(procs, sizeof(procs), cbNeeded)
-			if res != 1:
-				raise RuntimeError("EnumProcesses: %d" % res)
-			if cbNeeded.value == sizeof(procs):
-				nprocs *= 2
-			else:
-				break
-		n = cbNeeded.value // sizeof(DWORD)
-		procs=  list(procs)[:n]
 		our_pid = os.getpid()
-		buf = create_unicode_buffer(512)
-		size = DWORD()
-		for proc in procs:
-			size.value = 512
-			if proc == our_pid:
-				continue
-			h = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_TERMINATE, False, proc)
-			if h == 0:
-				continue
-			res = kernel32.QueryFullProcessImageNameW(h, 0, byref(buf), byref(size))
-			if res == 0:
-				kernel32.CloseHandle(h)
-				continue
-			if buf.value.lower().endswith(r'\nvda.exe'):
-				kernel32.TerminateProcess(h, 1)
-			kernel32.CloseHandle(h)
+		kernel32 = windll.kernel32
+
+		comtypes.CoInitialize()
+		try:
+			wmi = comtypes.client.CoGetObject("winmgmts:")
+			processes = wmi.ExecQuery("SELECT ProcessId, Name, CommandLine FROM Win32_Process WHERE Name = 'nvda.exe' OR Name = 'python.exe' OR Name = 'pythonw.exe'")
+
+			for process in processes:
+				pid = process.ProcessId
+				if pid == our_pid:
+					continue
+
+				name = process.Name.lower()
+				if name == 'nvda.exe':
+					h = kernel32.OpenProcess(PROCESS_TERMINATE, False, pid)
+					if h != 0:
+						try:
+							kernel32.TerminateProcess(h, 1)
+						finally:
+							kernel32.CloseHandle(h)
+				elif name in ('python.exe', 'pythonw.exe'):
+					cmdline = process.CommandLine
+					if cmdline and 'nvda.pyw' in cmdline.lower():
+						h = kernel32.OpenProcess(PROCESS_TERMINATE, False, pid)
+						if h != 0:
+							try:
+								kernel32.TerminateProcess(h, 1)
+							finally:
+								kernel32.CloseHandle(h)
+		finally:
+			comtypes.CoUninitialize()
+
 		# Terminate our process
 		h = kernel32.OpenProcess(PROCESS_TERMINATE, False, our_pid)
 		if h != 0:
-			kernel32.TerminateProcess(h, 1)
-			kernel32.CloseHandle(h)
+			try:
+				kernel32.TerminateProcess(h, 1)
+			finally:
+				kernel32.CloseHandle(h)

--- a/addon/globalPlugins/killNVDA.py
+++ b/addon/globalPlugins/killNVDA.py
@@ -32,11 +32,11 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			processes = wmi.ExecQuery("SELECT ProcessId, Name, CommandLine FROM Win32_Process WHERE Name = 'nvda.exe' OR Name = 'python.exe' OR Name = 'pythonw.exe'")
 
 			for process in processes:
-				pid = process.ProcessId
+				pid = process.Properties_("ProcessId").Value
 				if pid == our_pid:
 					continue
 
-				name = process.Name.lower()
+				name = process.Properties_("Name").Value.lower()
 				if name == 'nvda.exe':
 					h = kernel32.OpenProcess(PROCESS_TERMINATE, False, pid)
 					if h != 0:
@@ -45,7 +45,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 						finally:
 							kernel32.CloseHandle(h)
 				elif name in ('python.exe', 'pythonw.exe'):
-					cmdline = process.CommandLine
+					cmdline = process.Properties_("CommandLine").Value
 					if cmdline and 'nvda.pyw' in cmdline.lower():
 						h = kernel32.OpenProcess(PROCESS_TERMINATE, False, pid)
 						if h != 0:


### PR DESCRIPTION


Replace Win32 API process enumeration with WMI to enable killing NVDA instances running from source



The original approach only detected compiled nvda.exe processes. This change uses WMI queries to also find python.exe/pythonw.exe processes running nvda.pyw, allowing termination of source-based NVDA instances.



Key changes:

\- WMI query targets specific process names instead of enumerating all processes  

\- Command-line inspection detects 'nvda.pyw' in Python processes

\- Improved resource management with proper try/finally blocks

\- Version bump to 0.6.0



Tested: built copy while logged in, built copy on both desktops when not logged in, and source on desktop + built on secure desktop.

